### PR TITLE
Docker: Update varnish docker image version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN set -e; \
 	tar xavf dist.tar.gz --strip-components=1; \
 	cargo build --release
 
-FROM varnish:7.4
+FROM varnish:7.5
 USER root
 RUN set -e; \
 	apt-get update; \


### PR DESCRIPTION
### Summary
This PR updates the version of the Varnish docker image.

---

### The problem

Building the image works just fine, however running a container yields the following ABI error:

```
Error:
Message from VCC-compiler:
Incompatible VMOD reqwest
	File name: /usr/lib/varnish/vmods/libvmod_reqwest.so
	ABI mismatch, expected <Varnish 7.4.3 b659b7ae62b44c05888919c5c1cd03ba6eaec681>, got <Varnish 7.5.0 eef25264e5ca5f96a77129308edb83ccf84cb1b1>
('/etc/varnish/default.vcl' Line 2 Pos 8)
import reqwest;
-------#######-

Running VCC-compiler failed, exited with 2
VCL compilation failed
```