### PR TITLE
Increase VARNISHTEST_DURATION

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[env]
+VARNISHTEST_DURATION = "20s"


### PR DESCRIPTION
Some tests can take longer than the 5-second default